### PR TITLE
Add missing dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,10 @@
     "vtex.locale-switcher": "0.x",
     "vtex.product-quantity": "1.x",
     "vtex.product-identifier": "0.x",
-    "vtex.breadcrumb": "1.x"
+    "vtex.breadcrumb": "1.x",
+    "vtex.product-specification-badges": "0.x",
+    "vtex.product-review-interfaces": "1.x",
+    "vtex.order-placed": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
A recent change to the `builder-hub` prevents interfaces and blocks from leaking between apps.

Now it is necessary to explicitly list all apps you need as dependencies.